### PR TITLE
Version Specific Installation & Additional Unmentioned Dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,12 +196,13 @@ For automatic recognition, the song files in the selected folder should follow t
 3. **Install the required dependencies:**
   (To install using git, you must install [Git](https://git-scm.com/downloads).)
     ```bash
-    pip install PyQt5==5.15.10
-    pip install pygame==2.6.0
-    pip install git+https://github.com/qwertyquerty/pypresence.git@master
-    pip install mutagen==1.47.0
-    pip install pynput==1.7.7
-    pip install git+https://github.com/vorlie/PyQtDarkTheme.git@main --ignore-requires-python
+    py -m pip install PyQt5==5.15.10
+    py -m pip install pygame==2.6.0
+    py -m pip install git+https://github.com/qwertyquerty/pypresence.git@master
+    py -m pip install mutagen==1.47.0
+    py -m pip install pynput==1.7.7
+    py -m pip install matplotlib
+    py -m pip install git+https://github.com/vorlie/PyQtDarkTheme.git@main --ignore-requires-python
     ```
 
 4. **Ensure you have the necessary environment variables and configuration files:**


### PR DESCRIPTION
in order to ensure that libraries are available to pyinstaller, one ought to call pip through the py shorthand, which calls the main python version that the aforementioned module will default to.

additionally, matplotlib is another dependency that is required by IotaPlayer to successfully build and run.